### PR TITLE
Update deprecated extended_id parameter

### DIFF
--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -229,7 +229,7 @@ class ElectronicControlUnit:
 
         if not self._bus:
             raise RuntimeError("Not connected to CAN bus")
-        msg = can.Message(extended_id=True,
+        msg = can.Message(is_extended_id=True,
                           arbitration_id=can_id,
                           data=data,
                           is_fd=fd_format,


### PR DESCRIPTION
Using only is_extended_id is needed for compatibility with new python-can [4.0.0](https://github.com/hardbyte/python-can/milestone/8).