### PR TITLE
Fixes occurence count in DM1 messages

### DIFF
--- a/j1939/diagnostic_messages.py
+++ b/j1939/diagnostic_messages.py
@@ -17,7 +17,7 @@ class DTC:
             if self._cm != 0:
                 logger.error("DM01: deprecated spn conversion modes are not supported")
         else:
-            self._dtc = ((spn & 0xFFFF) | ((spn & 0x70000) << 5) | ((fmi & 0x1F) << 16) | (oc & 0x7F << 24))
+            self._dtc = ((spn & 0xFFFF) | ((spn & 0x70000) << 5) | ((fmi & 0x1F) << 16) | ((oc & 0x7F) << 24))
             self._spn = spn
             self._fmi = fmi
             self._oc = oc


### PR DESCRIPTION
Currently the occurrence count does not work when sending DM1 messages. Parenthesis were forgotten when converting spn fmi and oc to dtc. This fixes it. 