### PR TITLE
Fix isSet() deprecation warning and add functionality for wincom object

### DIFF
--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -271,7 +271,7 @@ class ElectronicControlUnit:
         to awake at the new events.
         """
         system = sys.platform
-        if "win" in system:
+        if system.startswith("win32") or system.startswith("cygwin"):
             import pythoncom
             pythoncom.CoInitialize()
 
@@ -309,7 +309,7 @@ class ElectronicControlUnit:
                     # do nothing
                     pass
 
-        if "win" in system:
+        if system.startswith("win32") or system.startswith("cygwin"):
             pythoncom.CoUnitialize()
 
     def _job_thread_wakeup(self):

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -2,6 +2,7 @@ import logging
 import can
 from can import Listener
 import time
+import sys
 import threading
 import queue
 from .controller_application import ControllerApplication
@@ -269,8 +270,10 @@ class ElectronicControlUnit:
         wakeup the timeout handler to recalculate the new sleep-time
         to awake at the new events.
         """
-        import pythoncom
-        pythoncom.CoInitialize()
+        system = sys.platform
+        if "win" in system:
+            import pythoncom
+            pythoncom.CoInitialize()
 
         while not self._job_thread_end.is_set():
 
@@ -306,7 +309,8 @@ class ElectronicControlUnit:
                     # do nothing
                     pass
 
-        pythoncom.CoUnitialize()
+        if "win" in system:
+            pythoncom.CoUnitialize()
 
     def _job_thread_wakeup(self):
         """Wakeup the async job thread

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -269,6 +269,9 @@ class ElectronicControlUnit:
         wakeup the timeout handler to recalculate the new sleep-time
         to awake at the new events.
         """
+        import pythoncom
+        pythoncom.CoInitialize()
+
         while not self._job_thread_end.isSet():
 
             now = time.time()
@@ -302,6 +305,8 @@ class ElectronicControlUnit:
                 except queue.Empty:
                     # do nothing
                     pass
+
+        pythoncom.CoUnitialize()
 
     def _job_thread_wakeup(self):
         """Wakeup the async job thread

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -272,7 +272,7 @@ class ElectronicControlUnit:
         import pythoncom
         pythoncom.CoInitialize()
 
-        while not self._job_thread_end.isSet():
+        while not self._job_thread_end.is_set():
 
             now = time.time()
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,2 @@
+from .feeder import Feeder
+from .feeder import AcceptAllCA

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,2 +1,0 @@
-from .feeder import Feeder
-from .feeder import AcceptAllCA


### PR DESCRIPTION
Fix #37 and fix #40. First, I fixed the isSet() deprecation warning that pytest will display. I just changed isSet() to is_set().

Additionally, I added the ability for a client to use a wincom object. Previously, if a client tried to constantly update a signal value using a wincom object, the library would throw an error due to the threading involved with j1939. To correct this, all is needed is to call pythoncom.CoInitialize() and pythoncom.CoUnitialize(), provided that the OS is Windows.