### PR TITLE
J1939_21: Set _minimum_tp_bam_dt_interval when not None

### DIFF
--- a/j1939/j1939_21.py
+++ b/j1939/j1939_21.py
@@ -53,6 +53,8 @@ class J1939_21:
         # set minimum time between two tp-bam messages
         if minimum_tp_bam_dt_interval == None:
             self._minimum_tp_bam_dt_interval = self.Timeout.Tb
+        else:
+            self._minimum_tp_bam_dt_interval = minimum_tp_bam_dt_interval
 
         # number of packets that can be sent/received with CMDT (Connection Mode Data Transfer)
         self._max_cmdt_packets = max_cmdt_packets


### PR DESCRIPTION
For J1939_21, there's an edge case check for when minimum TP BAM dt interval is None, but the regular case (when non-None is passed in) is not handled. I've added code to handle this case.