### PR TITLE
#60: reinstate missing copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2018 Frank Benkert (opensource@frank-benkert.de)
 Copyright (c) 2021 juergenH87
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Closes #60. 

The approach taken in this PR is inspired by [this stack exchange question & answer](https://opensource.stackexchange.com/questions/4439/how-to-deal-with-licences-after-forking-a-project), and simply adds the original copyright information back in, above the more recent copyright updates.

For reference, here is a link to the original copyright information in the project that this current project was forked from:
https://github.com/benkfra/j1939/blob/master/LICENSE 