### PR TITLE
Remove Remaining Call To pythoncom.CoUninitialize

### DIFF
--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -336,9 +336,6 @@ class ElectronicControlUnit:
                     # do nothing
                     pass
 
-        if system.startswith("win32") or system.startswith("cygwin"):
-            pythoncom.CoUninitialize()
-
     def _job_thread_wakeup(self):
         """Wakeup the async job thread
 


### PR DESCRIPTION
I believe there was already work to remove it, however, this was still trailing.  I was hitting this issue with a an error indicating that there was no module named "pythoncom".