### PR TITLE
feat: add configurability of timeouts

### DIFF
--- a/j1939/Dm14Query.py
+++ b/j1939/Dm14Query.py
@@ -213,6 +213,7 @@ class Dm14Query:
         object_byte_size: int = 1,
         signed: bool = False,
         return_raw_bytes: bool = False,
+        max_timeout: int = 1,
     ) -> list:
         """
         Send a read query to dest_address, requesting data at address
@@ -223,6 +224,7 @@ class Dm14Query:
         :param int object_byte_size: size of each object in bytes
         :param bool signed: whether the data is signed
         :param bool return_raw_bytes: whether to return raw bytes or values
+        :param int max_timeout: max timeout for transaction
         """
         assert object_count > 0
         self._dest_address = dest_address
@@ -255,6 +257,7 @@ class Dm14Query:
         address: int,
         values: list,
         object_byte_size: int = 1,
+        max_timeout: int = 1,
     ) -> None:
         """
         Send a write query to dest_address, requesting to write values at address
@@ -263,6 +266,7 @@ class Dm14Query:
         :param int address: address of the message
         :param list values: values to be written
         :param int object_byte_size: size of each object in bytes
+        :param int max_timeout: max timeout for transaction
         """
         self._dest_address = dest_address
         self.direct = direct
@@ -276,7 +280,7 @@ class Dm14Query:
         self.state = QueryState.WAIT_FOR_SEED
         # wait for operation completed DM15 message
         try:
-            self.data_queue.get(block=True, timeout=1)
+            self.data_queue.get(block=True, timeout=max_timeout)
             for _ in range(self.exception_queue.qsize()):
                 raise self.exception_queue.get(block=False, timeout=1)
         except queue.Empty:

--- a/j1939/Dm14Server.py
+++ b/j1939/Dm14Server.py
@@ -340,6 +340,7 @@ class DM14Server:
         data=None,
         error: int = 0xFFFFFF,
         edcp: int = 0xFF,
+        max_timeout: int = 3,
     ) -> list:
         """
         Respond to DM14 query with the requested data or confimation of operation is good to proceed
@@ -347,6 +348,7 @@ class DM14Server:
         :param list data: data to be sent to device
         :param int error: error code to be sent to device
         :param int edcp: value for edcp extension
+        :param int max_timeout: max time for transaction
         """
         if data is None:
             data = []
@@ -366,5 +368,5 @@ class DM14Server:
         self._wait_for_data()
         mem_data = None
         if self.state == ResponseState.WAIT_FOR_DM16:
-            mem_data = self.data_queue.get(block=True, timeout=3)
+            mem_data = self.data_queue.get(block=True, timeout=max_timeout)
         return mem_data


### PR DESCRIPTION
to account for potential delays in transactions created a way to configure the time the code will wait for a response before faulting out 