### PR TITLE
fill payload for single package dm1

### DIFF
--- a/j1939/diagnostic_messages.py
+++ b/j1939/diagnostic_messages.py
@@ -235,6 +235,14 @@ class Dm1:
             self._data.append((dtc >> 16) & 0xFF)
             self._data.append((dtc >> 24) & 0xFF)
 
+        # no dtcs to report
+        if len(self._data) == 2:
+            self._data.extend([0x00, 0x00, 0x00, 0x00, 0xff, 0xff])
+        # one dtc to report
+        elif len(self._data) == 6:
+            self._data.extend([0xff, 0xff])
+
+
         # Default Priority: 6
         # priority should be 7 when transport protocol is used (SAE J1939-21 requirement)
         if len(self._data) > 8:


### PR DESCRIPTION
When sending dm1 with no or one dtc the payload that is sent is not according to spec.

From J1939-73 JUN2020 Page 26:

> NOTE: When there is zero or one DTC to report, then unused bytes 7 and 8 of the CAN frame shall be set to 255 (as per SAE J1939-21).
> NOTE: When there are no active DTCs to report, each of bytes 3 through 6 shall be set to zero