### PR TITLE
fill in missing timeouts

### DIFF
--- a/j1939/Dm14Query.py
+++ b/j1939/Dm14Query.py
@@ -288,7 +288,7 @@ class Dm14Query:
         try:
             self.data_queue.get(block=True, timeout=max_timeout)
             for _ in range(self.exception_queue.qsize()):
-                raise self.exception_queue.get(block=False, timeout=1)
+                raise self.exception_queue.get(block=False, timeout=max_timeout)
         except queue.Empty:
             if self.state is QueryState.WAIT_FOR_SEED:
                 raise RuntimeError("No response from server")

--- a/j1939/Dm14Query.py
+++ b/j1939/Dm14Query.py
@@ -239,9 +239,15 @@ class Dm14Query:
         self._send_dm14(7)
         self.state = QueryState.WAIT_FOR_SEED
         # wait for operation completed DM15 message
-        raw_bytes = self.data_queue.get(block=True, timeout=1)
+        raw_bytes = None
+        try:
+            raw_bytes = self.data_queue.get(block=True, timeout=max_timeout)
+        except queue.Empty:
+            if self.state is QueryState.WAIT_FOR_SEED:
+                raise RuntimeError("No response from server")
+            pass
         for _ in range(self.exception_queue.qsize()):
-            raise self.exception_queue.get(block=False, timeout=1)
+            raise self.exception_queue.get(block=False, timeout=max_timeout)
         if raw_bytes:
             if self.return_raw_bytes:
                 return raw_bytes

--- a/test/test_memory_access.py
+++ b/test/test_memory_access.py
@@ -575,7 +575,7 @@ def test_dm14_read_timeout_error(feeder):
     Tests that the DM14 read query can react to timeout errors correctly
     :param feeder: can message feeder
     """
-    with pytest.raises(queue.Empty) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         feeder.can_messages = [
             (
                 Feeder.MsgType.CANTX,


### PR DESCRIPTION
I forgot to add the timeout to the read query so added that now, also changed the way raise exceptions for the empty query, was running into a use case where the query was empty but wasn't able to catch that exception from higher up code so raising an error like this makes it catchable in higher level code