### PR TITLE
Add new parameter to choose between BAM and RTS for Transport Protocol

### DIFF
--- a/j1939/controller_application.py
+++ b/j1939/controller_application.py
@@ -1,6 +1,7 @@
 import logging
 import j1939
 from .message_id import FrameFormat
+from .j1939_21 import J1939_21
 
 logger = logging.getLogger(__name__)
 
@@ -253,7 +254,7 @@ class ControllerApplication:
         mid = j1939.MessageId(priority=priority, parameter_group_number=parameter_group_number, source_address=self._device_address)
         self._ecu.send_message(mid.can_id, True, data)
 
-    def send_pgn(self, data_page, pdu_format, pdu_specific, priority, data, time_limit=0, frame_format=FrameFormat.FEFF):
+    def send_pgn(self, data_page, pdu_format, pdu_specific, priority, data, time_limit=0, frame_format=FrameFormat.FEFF, tp_connection_mode=J1939_21.ConnectionMode.ABORT):
         """send a pgn
         :param int data_page: data page
         :param int pdu_format: pdu format
@@ -263,11 +264,15 @@ class ControllerApplication:
         :param time_limit: option j1939-22 multi-pg: specify a time limit in s (e.g. 0.1 == 100ms),
         after this time, the multi-pg will be sent. several pgs can thus be combined in one multi-pg.
         0 or no time-limit means immediate sending.
+        :param tp_connection_mode: optional to j1939-21. specify a TP method to be used. If it's left to the default value,
+        then TP messages will be chosen between BAM or RTS/CTS based on following criteria:
+            # if the PF is between 0 and 239, the message is destination dependent when pdu_specific != 255
+            # if the PF is between 240 and 255, the message can only be broadcast
         """
         if self.state != ControllerApplication.State.NORMAL:
             raise RuntimeError("Could not send message unless address claiming has finished")
 
-        return self._ecu.send_pgn(data_page, pdu_format, pdu_specific, priority, self._device_address, data, time_limit, frame_format)
+        return self._ecu.send_pgn(data_page, pdu_format, pdu_specific, priority, self._device_address, data, time_limit, frame_format, tp_connection_mode)
 
     def send_request(self, data_page, pgn, destination):
         """send a request message

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -226,7 +226,7 @@ class ElectronicControlUnit:
             self._notifier.remove_listener(listener)
         self._notifier = None
 
-    def send_pgn(self, data_page, pdu_format, pdu_specific, priority, src_address, data, time_limit=0, frame_format=FrameFormat.FEFF):
+    def send_pgn(self, data_page, pdu_format, pdu_specific, priority, src_address, data, time_limit=0, frame_format=FrameFormat.FEFF, tp_connection_mode=J1939_21.ConnectionMode.ABORT):
         """send a pgn
         :param int data_page: data page
         :param int pdu_format: pdu format
@@ -238,7 +238,7 @@ class ElectronicControlUnit:
         after this time, the multi-pg will be sent. several pgs can thus be combined in one multi-pg.
         0 or no time-limit means immediate sending.
         """
-        return self.j1939_dll.send_pgn(data_page, pdu_format, pdu_specific, priority, src_address, data, time_limit, frame_format)
+        return self.j1939_dll.send_pgn(data_page, pdu_format, pdu_specific, priority, src_address, data, time_limit, frame_format, tp_connection_mode)
 
     def send_message(self, can_id, extended_id, data, fd_format=False):
         """Send a raw CAN message to the bus.

--- a/j1939/j1939_22.py
+++ b/j1939/j1939_22.py
@@ -190,7 +190,7 @@ class J1939_22:
     def __put_rts_cts_session(self, session):
         self.__rts_cts_session_list[session] = True
 
-    def send_pgn(self, data_page, pdu_format, pdu_specific, priority, src_address, data, time_limit, frame_format, tos=2, trailer_format=0):
+    def send_pgn(self, data_page, pdu_format, pdu_specific, priority, src_address, data, time_limit, frame_format, tp_connection_mode, tos=2, trailer_format=0):
         pgn = ParameterGroupNumber(data_page, pdu_format, pdu_specific)
         data_length = len(data)
 


### PR DESCRIPTION
Try to fix #96. We can't manually choose between BAM or RTS for the transport protocol because it's chosen for us based on the PF value. This PR adds a new parameter to send_pgn() function so that users can choose which TP method to use. This is a default parameter that only matters when the data is more than 8. 