### PR TITLE
Update multipacket send to have a que

### DIFF
--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -269,7 +269,7 @@ class ElectronicControlUnit:
             try:
                 self._bus.send(msg)
             except can.CanOperationError:
-                logger.error('not able to send message because CAN has not free Buffer space')
+                logger.error(f'not able to send message because {e}')
 
     def notify(self, can_id, data, timestamp):
         """Feed incoming CAN message into this ecu.

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -269,7 +269,7 @@ class ElectronicControlUnit:
             try:
                 self._bus.send(msg)
             except can.CanOperationError:
-                logger.info('not able to send message because CAN has not free Buffer space')
+                logger.error('not able to send message because CAN has not free Buffer space')
 
     def notify(self, can_id, data, timestamp):
         """Feed incoming CAN message into this ecu.

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -268,7 +268,7 @@ class ElectronicControlUnit:
                           )
             try:
                 self._bus.send(msg)
-            except can.CanOperationError:
+            except can.CanError as e:
                 logger.error(f'not able to send message because {e}')
 
     def notify(self, can_id, data, timestamp):

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -266,6 +266,7 @@ class ElectronicControlUnit:
                           is_fd=fd_format,
                           bitrate_switch=fd_format
                           )
+        with self._send_lock:
             try:
                 self._bus.send(msg)
             except can.CanError as e:

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -266,9 +266,10 @@ class ElectronicControlUnit:
                           is_fd=fd_format,
                           bitrate_switch=fd_format
                           )
-        with self._send_lock:
-            self._bus.send(msg)
-        # TODO: check error receivement
+            try:
+                self._bus.send(msg)
+            except can.CanOperationError:
+                logger.info('not able to send message because CAN has not free Buffer space')
 
     def notify(self, can_id, data, timestamp):
         """Feed incoming CAN message into this ecu.

--- a/j1939/j1939_21.py
+++ b/j1939/j1939_21.py
@@ -176,7 +176,7 @@ class J1939_21:
             if buffer_hash in self._snd_buffer:
                 # There is already a sequence active for this pair
                 # put in que
-                self._snd_que[pgn] = {'buffer_hash': buffer_hash,
+                self._snd_que[pgn.value] = {'buffer_hash': buffer_hash,
                                       'pdu_specific': pdu_specific,
                                       'priority': priority,
                                       'src_address':src_address,


### PR DESCRIPTION
Added multipacket send que, if multipacket send is busy, message will go to que and will be processed when next possible. If same message arrvies when in que values will be updated.

Also only set logging error when sending not possible, when other can partner reconnects automatically continues to send.

fixes #76 