### PR TITLE
Configure address claim delay

### DIFF
--- a/j1939/controller_application.py
+++ b/j1939/controller_application.py
@@ -123,16 +123,16 @@ class ControllerApplication:
         """
         self._ecu.remove_timer(callback)
 
-    def start(self, delay=0.5):
+    def start(self, claim_delay=0.5):
         """Starts the CA
-        :param delay:
+        :param claim_delay:
             The time in seconds to wait before starting the address claim procedure.
         """
         # TODO raise RuntimeError("Can't start CA. Seems to be already running.")? or just ignore?
         # check if we are not already started and there is an ecu connected
         if self._ecu and not self.started:
             self._started = True
-            self._ecu.add_timer(delay, self._process_claim_async)
+            self._ecu.add_timer(claim_delay, self._process_claim_async)
 
     def stop(self):
         """Stops the CA

--- a/j1939/controller_application.py
+++ b/j1939/controller_application.py
@@ -123,14 +123,16 @@ class ControllerApplication:
         """
         self._ecu.remove_timer(callback)
 
-    def start(self):
+    def start(self, delay=0.5):
         """Starts the CA
+        :param delay:
+            The time in seconds to wait before starting the address claim procedure.
         """
         # TODO raise RuntimeError("Can't start CA. Seems to be already running.")? or just ignore?
         # check if we are not already started and there is an ecu connected
         if self._ecu and not self.started:
             self._started = True
-            self._ecu.add_timer(0.500, self._process_claim_async)
+            self._ecu.add_timer(delay, self._process_claim_async)
 
     def stop(self):
         """Stops the CA

--- a/test/test_ca.py
+++ b/test/test_ca.py
@@ -47,6 +47,36 @@ def test_addr_claim_fixed(feeder):
 
     address_claim(feeder)
 
+def test_addr_claim_fixed_reduced_time(feeder):
+    """Test CA Address claim on the bus with fixed address
+    This test runs a "Single Address Capable" claim procedure with a fixed
+    address of 128. Tests a reduced time between start and first message.
+    """
+    feeder.can_messages = [
+        (Feeder.MsgType.CANTX, 0x18EEFF80, [135, 214, 82, 83, 130, 201, 254, 82], 0.0),    # Address Claimed
+    ]
+
+    name = j1939.Name(
+        arbitrary_address_capable=0, 
+        industry_group=j1939.Name.IndustryGroup.Industrial,
+        vehicle_system_instance=2,
+        vehicle_system=127,
+        function=201,
+        function_instance=16,
+        ecu_instance=2,
+        manufacturer_code=666,
+        identity_number=1234567,
+    )
+    new_ca = feeder.ecu.add_ca(name=name, device_address=128)
+    new_ca.start(0.25)
+    
+    # wait until all messages are processed asynchronously 
+    # rounded up to account for scheduling delays
+    time.sleep(0.3)
+
+    # assert that the expected message was sent
+    assert len(feeder.can_messages) == 0
+
 
 def test_addr_claim_fixed_veto_lose(feeder):
     """Test CA Address claim on the bus with fixed address and a veto counterpart


### PR DESCRIPTION
In some cases we may want to be able to configure how long we wait before starting the address claim process this helps if there's ever a case where address claiming needs to be completed by a certain deadline. Also in a typical device that runs j1939 it seems the address claim procedure typically starts after the initial internal checks are completed there's not a set delay in the standard from what I can tell. I could be wrong since I'm by no means an expert on it but from my understanding it seems to be  the case