### PR TITLE
feat: update stop_send method

### DIFF
--- a/j1939/diagnostic_messages.py
+++ b/j1939/diagnostic_messages.py
@@ -172,8 +172,11 @@ class Dm1:
         cookie = {'cb': callback,}
         self._ca.add_timer(delta_time=cycletime, callback=self._send, cookie=cookie)
 
-    def stop_send(self, callback):
-        self._ca.remove_timer(callback)
+    def stop_send(self):
+        """
+        Stop cyclic sending of Dm1 message
+        """
+        self._ca.remove_timer(callback=self._send)
 
     @property
     def dtc_dic_list(self):

--- a/j1939/diagnostic_messages.py
+++ b/j1939/diagnostic_messages.py
@@ -173,8 +173,7 @@ class Dm1:
         self._ca.add_timer(delta_time=cycletime, callback=self._send, cookie=cookie)
 
     def stop_send(self):
-        """
-        Stop cyclic sending of Dm1 message
+        """Stop cyclic sending of Dm1 message
         """
         self._ca.remove_timer(callback=self._send)
 


### PR DESCRIPTION
dm1 stop send method didn't work. I changed it to it this way and not the way that was recommended here https://github.com/juergenH87/python-can-j1939/issues/75 because I didn't think it made sense to have the ability to deregister individual pre-send methods inside a method called stop_send but if this is is what the intention for the method was then I can change my implementation. 