### PR TITLE
Feature/update seed key

### DIFF
--- a/j1939/Dm14Server.py
+++ b/j1939/Dm14Server.py
@@ -321,7 +321,10 @@ class DM14Server:
         :param int key: key
         """
         if self._verify_key is not None:
-            return self._verify_key(seed, key)
+            # TODO: add ability to dynamically pass arguments to verification function if needed,
+            # if this is breaking can just add *args to function defintion used to set the verification function
+            # this will allow for the reception of additional arguments if needed
+            return self._verify_key(seed, key, self.bytes_to_int(self.address), self.sa)
         return True if self._key_from_seed(seed) == key else False
 
     def reset_query(self) -> None:

--- a/j1939/Dm14Server.py
+++ b/j1939/Dm14Server.py
@@ -29,6 +29,7 @@ class DM14Server:
         self._key_from_seed = None
         self.data_queue = queue.Queue()
         self._seed_generator = self.generate_seed
+        self._verify_key = None
         self.address = None
         self.length = 8
         self.proceed = False
@@ -306,12 +307,21 @@ class DM14Server:
         """
         self._seed_generator = algorithm
 
+    def set_verify_key(self, algorithm: callable) -> None:
+        """
+        Set key verification algorithm to be used for key verification
+        :param callable algorithm: key verification algorithm
+        """
+        self._verify_key = algorithm
+
     def verify_key(self, seed: int, key: int) -> bool:
         """
         Checks to see if key is valid
         :param int seed: seed
         :param int key: key
         """
+        if self._verify_key is not None:
+            return self._verify_key(seed, key)
         return True if self._key_from_seed(seed) == key else False
 
     def reset_query(self) -> None:

--- a/j1939/Dm14Server.py
+++ b/j1939/Dm14Server.py
@@ -322,9 +322,11 @@ class DM14Server:
         """
         if self._verify_key is not None:
             # TODO: add ability to dynamically pass arguments to verification function if needed,
-            # if this is breaking can just add *args to function defintion used to set the verification function
+            # if this is breaking can just add **kwargs to function defintion used to set the verification function
             # this will allow for the reception of additional arguments if needed
-            return self._verify_key(seed, key, self.bytes_to_int(self.address), self.sa)
+            return self._verify_key(
+                seed=seed, key=key, address=self.bytes_to_int(self.address), sa=self.sa
+            )
         return True if self._key_from_seed(seed) == key else False
 
     def reset_query(self) -> None:

--- a/j1939/Dm14Server.py
+++ b/j1939/Dm14Server.py
@@ -327,7 +327,7 @@ class DM14Server:
             return self._verify_key(
                 seed=seed, key=key, address=self.bytes_to_int(self.address), sa=self.sa
             )
-        return True if self._key_from_seed(seed) == key else False
+        return self._key_from_seed(seed) == key
 
     def reset_query(self) -> None:
         """

--- a/j1939/memory_access.py
+++ b/j1939/memory_access.py
@@ -236,6 +236,13 @@ class MemoryAccess:
         self.query.set_seed_key_algorithm(algorithm)
         self.server.set_seed_key_algorithm(algorithm)
 
+    def set_verify_key(self, verify_key: callable) -> None:
+        """
+        set verify key function to be used for verifying the key
+        :param callable verify_key: verify key function
+        """
+        self.server.set_verify_key(verify_key)
+
     def set_notify(self, notify: callable) -> None:
         """
         set notify function to be used for notifying the user of memory accesses

--- a/test/test_memory_access.py
+++ b/test/test_memory_access.py
@@ -163,6 +163,10 @@ def generate_seed():
     return 0xA55A
 
 
+def verify_key(key, seed, **_):
+    return key == key_from_seed(seed)
+
+
 def get_error():
     return [(e.value) for e in j1939.J1939Error]
 
@@ -428,6 +432,7 @@ def test_dm14_request_write(feeder, expected_messages):
 
     if expected_messages == request_write_with_seed:
         dm14.set_seed_key_algorithm(key_from_seed)
+        dm14.set_verify_key(verify_key)
     values = 0x11223344
     while flag is False:
         pass


### PR DESCRIPTION
add the ability to override seed-key-verification default with custom logic. Expanded the verify check to take in more arguments in case it's needed for any other checks. Not sure how to eloquently handle this yet but for now if they aren't required just utilize the workaround for continued support. And look at example inside the test. The **_ represents unused kwargs