### PR TITLE
Improve some memory access functionality

### DIFF
--- a/j1939/Dm14Query.py
+++ b/j1939/Dm14Query.py
@@ -76,7 +76,7 @@ class Dm14Query:
         else:
             self.state = QueryState.WAIT_FOR_DM16
             self._ca.unsubscribe(self._parse_dm15)
-            self._ca.unique_subscribe(self._parse_dm16)
+            self._ca.subscribe(self._parse_dm16)
 
     def _send_operation_complete(self) -> None:
         """
@@ -196,7 +196,7 @@ class Dm14Query:
         # assert object_count == self.object_count
         self.mem_data = data[1 : length + 1]
         self._ca.unsubscribe(self._parse_dm16)
-        self._ca.unique_subscribe(self._parse_dm15)
+        self._ca.subscribe(self._parse_dm15)
         self.state = QueryState.WAIT_FOR_OPER_COMPLETE
 
     def _values_to_bytes(self, values: list) -> bytearray:
@@ -256,7 +256,7 @@ class Dm14Query:
         self.signed = signed
         self.return_raw_bytes = return_raw_bytes
         self.command = Command.READ
-        self._ca.unique_subscribe(self._parse_dm15)
+        self._ca.subscribe(self._parse_dm15)
         self._send_dm14(self.user_level)
         self.state = QueryState.WAIT_FOR_SEED
         # wait for operation completed DM15 message
@@ -302,7 +302,7 @@ class Dm14Query:
         self.command = Command.WRITE
         self.bytes = self._values_to_bytes(values)
         self.object_count = len(values)
-        self._ca.unique_subscribe(self._parse_dm15)
+        self._ca.subscribe(self._parse_dm15)
         self._send_dm14(self.user_level)
         self.state = QueryState.WAIT_FOR_SEED
         # wait for operation completed DM15 message

--- a/j1939/Dm14Query.py
+++ b/j1939/Dm14Query.py
@@ -45,6 +45,25 @@ class Dm14Query:
         self.exception_queue = queue.Queue()
         self.user_level = user_level
 
+    def reset_query(self) -> None:
+        """
+        Resets query to remove transaction specific data
+        """
+        self.state = QueryState.IDLE
+        self._dest_address = None
+        self.address = None
+        self.object_count = 0
+        self.object_byte_size = 1
+        self.signed = False
+        self.return_raw_bytes = False
+        self.direct = 0
+        self.command = None
+        self.bytes = bytearray()
+        self.mem_data = None
+        self.data_queue = queue.Queue()
+        self.exception_queue = queue.Queue()
+
+
     def _wait_for_data(self) -> None:
         """
         Determines whether to send data or wait to receive data based on the command type. If the command is a write command, then the data is sent.

--- a/j1939/Dm14Query.py
+++ b/j1939/Dm14Query.py
@@ -45,6 +45,13 @@ class Dm14Query:
         self.exception_queue = queue.Queue()
         self.user_level = user_level
 
+    def unsubscribe_all(self) -> None:
+        """
+        Unsubscribes all message handlers
+        """
+        self._ca.unsubscribe(self._parse_dm15)
+        self._ca.unsubscribe(self._parse_dm16)
+        
     def reset_query(self) -> None:
         """
         Resets query to remove transaction specific data
@@ -62,6 +69,7 @@ class Dm14Query:
         self.mem_data = None
         self.data_queue = queue.Queue()
         self.exception_queue = queue.Queue()
+        self.unsubscribe_all()
 
 
     def _wait_for_data(self) -> None:

--- a/j1939/Dm14Query.py
+++ b/j1939/Dm14Query.py
@@ -76,7 +76,7 @@ class Dm14Query:
         else:
             self.state = QueryState.WAIT_FOR_DM16
             self._ca.unsubscribe(self._parse_dm15)
-            self._ca.subscribe(self._parse_dm16)
+            self._ca.unique_subscribe(self._parse_dm16)
 
     def _send_operation_complete(self) -> None:
         """
@@ -196,7 +196,7 @@ class Dm14Query:
         # assert object_count == self.object_count
         self.mem_data = data[1 : length + 1]
         self._ca.unsubscribe(self._parse_dm16)
-        self._ca.subscribe(self._parse_dm15)
+        self._ca.unique_subscribe(self._parse_dm15)
         self.state = QueryState.WAIT_FOR_OPER_COMPLETE
 
     def _values_to_bytes(self, values: list) -> bytearray:
@@ -256,7 +256,7 @@ class Dm14Query:
         self.signed = signed
         self.return_raw_bytes = return_raw_bytes
         self.command = Command.READ
-        self._ca.subscribe(self._parse_dm15)
+        self._ca.unique_subscribe(self._parse_dm15)
         self._send_dm14(self.user_level)
         self.state = QueryState.WAIT_FOR_SEED
         # wait for operation completed DM15 message
@@ -302,7 +302,7 @@ class Dm14Query:
         self.command = Command.WRITE
         self.bytes = self._values_to_bytes(values)
         self.object_count = len(values)
-        self._ca.subscribe(self._parse_dm15)
+        self._ca.unique_subscribe(self._parse_dm15)
         self._send_dm14(self.user_level)
         self.state = QueryState.WAIT_FOR_SEED
         # wait for operation completed DM15 message

--- a/j1939/Dm14Server.py
+++ b/j1939/Dm14Server.py
@@ -161,9 +161,7 @@ class DM14Server:
                 self.state = ResponseState.SEND_PROCEED
 
             case ResponseState.WAIT_OPERATION_COMPLETE:
-                self.state = ResponseState.IDLE
-                self.sa = None
-                self._ca.unsubscribe(self.parse_dm14)
+                self.reset_server()
 
             case _:
                 raise ValueError("Invalid state")
@@ -255,12 +253,12 @@ class DM14Server:
 
         if pgn != j1939.ParameterGroupNumber.PGN.DM16 or sa != self.sa:
             return
-
         length = min(data[0], len(data) - 1)
         self.data_queue.put(data[1 : length + 1])
         self._ca.unsubscribe(self._parse_dm16)
         self._ca.subscribe(self.parse_dm14)
         self.state = ResponseState.SEND_OPERATION_COMPLETE
+
         self._send_dm15(
             self.length,
             self.direct,
@@ -329,6 +327,13 @@ class DM14Server:
             )
         return self._key_from_seed(seed) == key
 
+    def unsubscribe_all(self) -> None:
+        """
+        Unsubscribes all message handlers
+        """
+        self._ca.unsubscribe(self.parse_dm14)
+        self._ca.unsubscribe(self._parse_dm16)
+
     def reset_server(self) -> None:
         """
         Resets server to remove transaction specific data
@@ -347,8 +352,7 @@ class DM14Server:
         self.edcp = 0x07
         self.status = j1939.Dm15Status.PROCEED.value
         self.direct = 0
-        self._ca.unsubscribe(self.parse_dm14)
-        self._ca.unsubscribe(self._parse_dm16)
+        self.unsubscribe_all()
 
     def respond(
         self,

--- a/j1939/Dm14Server.py
+++ b/j1939/Dm14Server.py
@@ -164,6 +164,7 @@ class DM14Server:
                 self.reset_server()
 
             case _:
+                self.reset_server()
                 raise ValueError("Invalid state")
 
     def _send_dm15(
@@ -220,6 +221,7 @@ class DM14Server:
                 data[length - 3] = edcp
 
             case _:
+                self.reset_server()
                 raise ValueError("Invalid state")
         self._ca.send_pgn(0, (pgn >> 8) & 0xFF, sa & 0xFF, 6, data)
 

--- a/j1939/Dm14Server.py
+++ b/j1939/Dm14Server.py
@@ -329,11 +329,12 @@ class DM14Server:
             )
         return self._key_from_seed(seed) == key
 
-    def reset_query(self) -> None:
+    def reset_server(self) -> None:
         """
-        Resets query to initial state
+        Resets server to remove transaction specific data
         """
         self.state = ResponseState.IDLE
+        self.data_queue = queue.Queue()
         self.sa = None
         self.seed = None
         self.key = None

--- a/j1939/Dm14Server.py
+++ b/j1939/Dm14Server.py
@@ -44,7 +44,7 @@ class DM14Server:
         Determines whether to send data or wait to receive data based on the command type.
         If the command is a read command, then the data requested is sent.
         """
-        self._ca.unique_subscribe(self._parse_dm16)
+        self._ca.subscribe(self._parse_dm16)
         self._send_dm15(
             self.length,
             self.direct,
@@ -66,7 +66,7 @@ class DM14Server:
             if (len(self.data)) <= 8:
                 self.proceed = True
                 self.state = ResponseState.SEND_OPERATION_COMPLETE
-                self._ca.unique_subscribe(self.parse_dm14)
+                self._ca.subscribe(self.parse_dm14)
                 self._send_dm15(
                     self.length,
                     self.direct,
@@ -238,7 +238,7 @@ class DM14Server:
 
         data.extend([0xFF] * (self.length - byte_count - 1))
         if byte_count > 8:
-            self._ca.unique_subscribe(self._parse_dm16)
+            self._ca.subscribe(self._parse_dm16)
         self._ca.send_pgn(0, (self._pgn >> 8) & 0xFF, self.sa & 0xFF, 7, data)
 
     def _parse_dm16(
@@ -259,7 +259,7 @@ class DM14Server:
         length = min(data[0], len(data) - 1)
         self.data_queue.put(data[1 : length + 1])
         self._ca.unsubscribe(self._parse_dm16)
-        self._ca.unique_subscribe(self.parse_dm14)
+        self._ca.subscribe(self.parse_dm14)
         self.state = ResponseState.SEND_OPERATION_COMPLETE
         self._send_dm15(
             self.length,

--- a/j1939/Dm14Server.py
+++ b/j1939/Dm14Server.py
@@ -44,7 +44,7 @@ class DM14Server:
         Determines whether to send data or wait to receive data based on the command type.
         If the command is a read command, then the data requested is sent.
         """
-        self._ca.subscribe(self._parse_dm16)
+        self._ca.unique_subscribe(self._parse_dm16)
         self._send_dm15(
             self.length,
             self.direct,
@@ -66,7 +66,7 @@ class DM14Server:
             if (len(self.data)) <= 8:
                 self.proceed = True
                 self.state = ResponseState.SEND_OPERATION_COMPLETE
-                self._ca.subscribe(self.parse_dm14)
+                self._ca.unique_subscribe(self.parse_dm14)
                 self._send_dm15(
                     self.length,
                     self.direct,
@@ -238,7 +238,7 @@ class DM14Server:
 
         data.extend([0xFF] * (self.length - byte_count - 1))
         if byte_count > 8:
-            self._ca.subscribe(self._parse_dm16)
+            self._ca.unique_subscribe(self._parse_dm16)
         self._ca.send_pgn(0, (self._pgn >> 8) & 0xFF, self.sa & 0xFF, 7, data)
 
     def _parse_dm16(
@@ -259,7 +259,7 @@ class DM14Server:
         length = min(data[0], len(data) - 1)
         self.data_queue.put(data[1 : length + 1])
         self._ca.unsubscribe(self._parse_dm16)
-        self._ca.subscribe(self.parse_dm14)
+        self._ca.unique_subscribe(self.parse_dm14)
         self.state = ResponseState.SEND_OPERATION_COMPLETE
         self._send_dm15(
             self.length,

--- a/j1939/controller_application.py
+++ b/j1939/controller_application.py
@@ -77,6 +77,13 @@ class ControllerApplication:
         """
         self._ecu.subscribe(callback, self.message_acceptable)
 
+    def unique_subscribe(self, callback):
+        """Add the given callback to the message notification stream only once.
+        :param callback:
+            Function to call when message is received.
+        """
+        self._ecu.unique_subscribe(callback, self.message_acceptable)
+        
     def unsubscribe(self, callback):
         """Stop listening for message.
         :param callback:

--- a/j1939/controller_application.py
+++ b/j1939/controller_application.py
@@ -76,13 +76,6 @@ class ControllerApplication:
             Function to call when message is received.
         """
         self._ecu.subscribe(callback, self.message_acceptable)
-
-    def unique_subscribe(self, callback):
-        """Add the given callback to the message notification stream only once.
-        :param callback:
-            Function to call when message is received.
-        """
-        self._ecu.unique_subscribe(callback, self.message_acceptable)
         
     def unsubscribe(self, callback):
         """Stop listening for message.

--- a/j1939/controller_application.py
+++ b/j1939/controller_application.py
@@ -76,7 +76,7 @@ class ControllerApplication:
             Function to call when message is received.
         """
         self._ecu.subscribe(callback, self.message_acceptable)
-        
+
     def unsubscribe(self, callback):
         """Stop listening for message.
         :param callback:

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -132,7 +132,7 @@ class ElectronicControlUnit:
         self._bus = None
 
     def subscribe(self, callback, device_address=None):
-        """Add the given callback to the message notification stream. If it's not already subscribed
+        """Add the given callback to the message notification stream.
 
         :param callback:
             Function to call when message is received.
@@ -142,9 +142,6 @@ class ElectronicControlUnit:
             Only one device address can be entered. Multiple device addresses are only possible with controller applications.
             Note: TP.CMDT will only be received if the destination address is bound to a controller application.
         """
-        for dic in self._subscribers:
-            if dic['cb'] == callback and dic['dev_adr'] == device_address:
-                return
         self._subscribers.append({'cb': callback, 'dev_adr':device_address})
 
     def unsubscribe(self, callback):
@@ -377,7 +374,10 @@ class ElectronicControlUnit:
         logger.debug("notify subscribers for PGN {}".format(pgn))
         # notify only the CA for which the message is intended
         # each CA receives all broadcast messages
-        for dic in self._subscribers:
+
+        # TODO: this is ineffecient but there exists a possibility of removing subscribers during callback
+        # and adding new ones in while this is going and it can impact message receivement
+        for dic in self._subscribers.copy():
             if (dic['dev_adr'] == None) or (dest == ParameterGroupNumber.Address.GLOBAL) or (callable(dic['dev_adr']) and dic['dev_adr'](dest)) or (dest == dic['dev_adr']):
                 dic['cb'](priority, pgn, sa, timestamp, data)
 

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -144,6 +144,20 @@ class ElectronicControlUnit:
         """
         self._subscribers.append({'cb': callback, 'dev_adr':device_address})
 
+    def unique_subscribe(self, callback, device_address=None):
+        """Add the given callback to the message notification stream only once.
+
+        :param callback:
+            Function to call when message is received.
+        :param int device_address:
+            Device address of the application.
+            This is a simple way for peer-to-peer reception without adding a controller-application.
+        """
+        for dic in self._subscribers:
+            if dic['cb'] == callback:
+                return
+        self._subscribers.append({'cb': callback, 'dev_adr':device_address})
+
     def unsubscribe(self, callback):
         """Stop listening for message.
 
@@ -288,7 +302,7 @@ class ElectronicControlUnit:
         """
         self.j1939_dll.notify(can_id, data, timestamp)
 
-    def add_bus_filters(self, fitlers: can.typechecking.CanFilters | None):
+    def add_bus_filters(self, filters: can.typechecking.CanFilters | None):
         """Add bus filters to the underlying CAN bus.
 
          :param filters:
@@ -297,7 +311,7 @@ class ElectronicControlUnit:
         """
         if self._bus is None:
             raise RuntimeError("Not connected to CAN bus")
-        self._bus.set_filters(fitlers)
+        self._bus.set_filters(filters)
 
     def _async_job_thread(self):
         """Asynchronous thread for handling various jobs

--- a/j1939/electronic_control_unit.py
+++ b/j1939/electronic_control_unit.py
@@ -132,7 +132,7 @@ class ElectronicControlUnit:
         self._bus = None
 
     def subscribe(self, callback, device_address=None):
-        """Add the given callback to the message notification stream.
+        """Add the given callback to the message notification stream. If it's not already subscribed
 
         :param callback:
             Function to call when message is received.
@@ -142,19 +142,8 @@ class ElectronicControlUnit:
             Only one device address can be entered. Multiple device addresses are only possible with controller applications.
             Note: TP.CMDT will only be received if the destination address is bound to a controller application.
         """
-        self._subscribers.append({'cb': callback, 'dev_adr':device_address})
-
-    def unique_subscribe(self, callback, device_address=None):
-        """Add the given callback to the message notification stream only once.
-
-        :param callback:
-            Function to call when message is received.
-        :param int device_address:
-            Device address of the application.
-            This is a simple way for peer-to-peer reception without adding a controller-application.
-        """
         for dic in self._subscribers:
-            if dic['cb'] == callback:
+            if dic['cb'] == callback and dic['dev_adr'] == device_address:
                 return
         self._subscribers.append({'cb': callback, 'dev_adr':device_address})
 

--- a/j1939/memory_access.py
+++ b/j1939/memory_access.py
@@ -266,6 +266,6 @@ class MemoryAccess:
         Resets both server and query to remove transaction specific data
         """
         self.state = DMState.IDLE
-        self._ca.unique_subscribe(self._listen_for_dm14)
+        self._ca.subscribe(self._listen_for_dm14)
         self.server.reset_server()
         self.query.reset_query()

--- a/j1939/memory_access.py
+++ b/j1939/memory_access.py
@@ -13,6 +13,7 @@ class MemoryAccess:
     def __init__(self, ca: j1939.ControllerApplication) -> None:
         """
         Makes an overarching Memory access class
+
         :param ca: Controller Application
         """
         self._ca = ca
@@ -22,14 +23,33 @@ class MemoryAccess:
         self.state = DMState.IDLE
         self.seed_security = False
         self._notify_query_received = None
-        self._seed_key_valid = None
         self._proceed_function = None
+
+    def _handle_error(self, priority: int, pgn: int, sa: int, timestamp: int, data: bytearray, error_code: int) -> None:
+        """
+        Handles errors by resetting the state and unsubscribing from DM14 messages
+
+        :param priority: Priority of the message
+        :param pgn: Parameter Group Number of the message
+        :param sa: Source Address of the message
+        :param timestamp: Timestamp of the message
+        :param data: Data of the PDU
+        :param error_code: Error code to be set
+        """
+        self.server.error = error_code
+        self.server.set_busy(True)
+        self.server.parse_dm14(
+            priority, pgn, sa, timestamp, data
+        )
+        self.server.set_busy(False)
+        self.reset()
 
     def _listen_for_dm14(
         self, priority: int, pgn: int, sa: int, timestamp: int, data: bytearray
     ) -> None:
         """
         Listens for dm14 messages and passes them to the appropriate function
+
         :param priority: Priority of the message
         :param pgn: Parameter Group Number of the message
         :param sa: Source Address of the message
@@ -64,15 +84,7 @@ class MemoryAccess:
                                 if self.proceed:
                                     self._notify_query_received()  # notify incoming request
                                 else:
-                                    self.server.error = 0x100
-                                    self.server.set_busy(True)
-                                    self.server.parse_dm14(
-                                        priority, pgn, sa, timestamp, data
-                                    )
-                                    self.server.set_busy(False)
-                                    self.server.reset_query()
-                                    self.state = DMState.IDLE
-                                    self.server.error = 0x0
+                                    self._handle_error(priority, pgn, sa, timestamp, data, 0x100)
 
                 case DMState.REQUEST_STARTED:
                     self.server.parse_dm14(priority, pgn, sa, timestamp, data)
@@ -101,24 +113,9 @@ class MemoryAccess:
                                     if self.proceed:
                                         self._notify_query_received()  # notify incoming request
                                     else:
-                                        self.server.error = 0x100
-                                        self.server.set_busy(True)
-                                        self.server.parse_dm14(
-                                            priority, pgn, sa, timestamp, data
-                                        )
-                                        self.server.set_busy(False)
-                                        self.server.reset_query()
-                                        self.state = DMState.IDLE
-                                        self.server.error = 0x0
+                                        self._handle_error(priority, pgn, sa, timestamp, data, 0x100)
                             else:
-                                self.server.error = 0x1003
-                                self.server.set_busy(True)
-                                self.server.parse_dm14(
-                                    priority, pgn, sa, timestamp, data
-                                )
-                                self.server.set_busy(False)
-                                self.state = DMState.IDLE
-                                self.server.error = 0x0
+                                self._handle_error(priority, pgn, sa, timestamp, data, 0x1003)
 
                 case DMState.WAIT_QUERY:
                     self.server.set_busy(True)
@@ -137,6 +134,7 @@ class MemoryAccess:
     ) -> list:
         """
         Responds with requested data and error code, if applicable, to a read request
+
         :param bool proceed: whether the operation is good to proceed
         :param list data: data to be sent to device
         :param int error: error code to be sent to device
@@ -189,7 +187,7 @@ class MemoryAccess:
                 return_raw_bytes,
                 max_timeout,
             )
-            self.state = DMState.IDLE
+            self.reset()
             return data
         else:
             raise RuntimeWarning("Process already Running")
@@ -205,6 +203,7 @@ class MemoryAccess:
     ) -> None:
         """
         Send a write query to dest_address, requesting to write values at address
+
         :param int dest_address: destination address of the message
         :param int direct: direct address of the message
         :param int address: address of the message
@@ -218,18 +217,20 @@ class MemoryAccess:
             self.query.write(
                 dest_address, direct, address, values, object_byte_size, max_timeout
             )
-            self.state = DMState.IDLE
+            self.reset()
 
     def set_seed_generator(self, seed_generator: callable) -> None:
         """
         Sets seed generator function to use
+
         :param seed_generator: seed generator function
         """
         self.server.set_seed_generator(seed_generator)
 
     def set_seed_key_algorithm(self, algorithm: callable) -> None:
         """
-        set seed-key algorithm to be used for key generation
+        Sets seed-key algorithm to be used for key generation
+
         :param callable algorithm: seed-key algorithm
         """
         self.seed_security = True
@@ -238,28 +239,33 @@ class MemoryAccess:
 
     def set_verify_key(self, verify_key: callable) -> None:
         """
-        set verify key function to be used for verifying the key
+        Sets verify key function to be used for verifying the key
+
         :param callable verify_key: verify key function
         """
         self.server.set_verify_key(verify_key)
 
     def set_notify(self, notify: callable) -> None:
         """
-        set notify function to be used for notifying the user of memory accesses
+        Sets notify function to be used for notifying the user of memory accesses
+
         :param callable notify: notify function
         """
         self._notify_query_received = notify
 
     def set_proceed(self, proceed: callable) -> None:
         """
-        set proceed function to determine if a memory query is valid or not
+        Sets proceed function to determine if a memory query is valid or not
+
         :param callable proceed: proceed function
         """
         self._proceed_function = proceed
 
-    def reset_query(self) -> None:
+    def reset(self) -> None:
         """
-        reset query for the server
+        Resets both server and query to remove transaction specific data
         """
-        self._ca.subscribe(self._listen_for_dm14)
-        self.server.reset_query()
+        self.state = DMState.IDLE
+        self._ca.unique_subscribe(self._listen_for_dm14)
+        self.server.reset_server()
+        self.query.reset_query()

--- a/j1939/memory_access.py
+++ b/j1939/memory_access.py
@@ -7,6 +7,7 @@ class DMState(Enum):
     REQUEST_STARTED = 2
     WAIT_RESPONSE = 3
     WAIT_QUERY = 4
+    SERVER_CLEANUP = 5
 
 
 class MemoryAccess:
@@ -121,9 +122,11 @@ class MemoryAccess:
                     self.server.set_busy(True)
                     self.server.parse_dm14(priority, pgn, sa, timestamp, data)
                     self.server.set_busy(False)
+                case DMState.SERVER_CLEANUP:
+                    self.state = DMState.IDLE
                 case _:
                     pass
-
+        
     def respond(
         self,
         proceed: bool,
@@ -143,14 +146,15 @@ class MemoryAccess:
         """
         if data is None:
             data = []
-        if self.state is DMState.WAIT_RESPONSE:
-            self._ca.unsubscribe(self._listen_for_dm14)
-            self.state = DMState.IDLE
-            return_data = self.server.respond(proceed, data, error, edcp, max_timeout)
-            self._ca.subscribe(self._listen_for_dm14)
-            return return_data
-        else:
+        
+        if self.state is not DMState.WAIT_RESPONSE:
             return data
+        
+        self._ca.unsubscribe(self._listen_for_dm14)
+        return_data = self.server.respond(proceed, data, error, edcp, max_timeout)
+        self.state = DMState.SERVER_CLEANUP if self.server.state.value != DMState.IDLE.value else DMState.IDLE
+        self._ca.subscribe(self._listen_for_dm14)
+        return return_data
 
     def read(
         self,
@@ -165,6 +169,7 @@ class MemoryAccess:
     ) -> list:
         """
         Make a dm14 read Query
+
         :param int dest_address: destination address of the message
         :param int direct: direct address of the message
         :param int address: address of the message
@@ -190,6 +195,7 @@ class MemoryAccess:
             self.reset()
             return data
         else:
+            self.reset()
             raise RuntimeWarning("Process already Running")
 
     def write(
@@ -222,7 +228,6 @@ class MemoryAccess:
     def set_seed_generator(self, seed_generator: callable) -> None:
         """
         Sets seed generator function to use
-
         :param seed_generator: seed generator function
         """
         self.server.set_seed_generator(seed_generator)
@@ -266,6 +271,7 @@ class MemoryAccess:
         Resets both server and query to remove transaction specific data
         """
         self.state = DMState.IDLE
+        self._ca.unsubscribe(self._listen_for_dm14)
         self._ca.subscribe(self._listen_for_dm14)
         self.server.reset_server()
         self.query.reset_query()

--- a/test/test_ecu.py
+++ b/test/test_ecu.py
@@ -201,9 +201,9 @@ def test_add_bus_filters(feeder):
     feeder.ecu.add_bus_filters(filters)
     assert feeder.ecu._bus.filters == filters
 
-def test_subscribe_unique(feeder):
+def test_subscribe(feeder):
     """
-    Test unique subscribing to messages
+    Test subscribing to callback only once
     """
     call_count = 0
 
@@ -211,8 +211,8 @@ def test_subscribe_unique(feeder):
         nonlocal call_count
         call_count += 1
 
-    feeder.ecu.unique_subscribe(callback)
-    feeder.ecu.unique_subscribe(callback)  # should not add again
+    feeder.ecu.subscribe(callback)
+    feeder.ecu.subscribe(callback)  # should not add again
     
     feeder.can_messages = [
         (Feeder.MsgType.CANRX, 0x00FEB201, [1, 2, 3, 4, 5, 6, 7, 8], 0.0),

--- a/test/test_ecu.py
+++ b/test/test_ecu.py
@@ -207,7 +207,7 @@ def test_subscribe_unique(feeder):
     """
     call_count = 0
 
-    def callback(msg):
+    def callback(priority: int, pgn: int, sa: int, timestamp: int, data: bytearray):
         nonlocal call_count
         call_count += 1
 
@@ -217,6 +217,8 @@ def test_subscribe_unique(feeder):
     feeder.can_messages = [
         (Feeder.MsgType.CANRX, 0x00FEB201, [1, 2, 3, 4, 5, 6, 7, 8], 0.0),
     ]
+
+    feeder.pdus = [(Feeder.MsgType.PDU, 65202, [1, 2, 3, 4, 5, 6, 7, 8])]
 
     feeder.receive()
 

--- a/test/test_ecu.py
+++ b/test/test_ecu.py
@@ -203,7 +203,7 @@ def test_add_bus_filters(feeder):
 
 def test_subscribe(feeder):
     """
-    Test subscribing to callback only once
+    Test subscribing to callback
     """
     call_count = 0
 
@@ -212,7 +212,6 @@ def test_subscribe(feeder):
         call_count += 1
 
     feeder.ecu.subscribe(callback)
-    feeder.ecu.subscribe(callback)  # should not add again
     
     feeder.can_messages = [
         (Feeder.MsgType.CANRX, 0x00FEB201, [1, 2, 3, 4, 5, 6, 7, 8], 0.0),

--- a/test/test_ecu.py
+++ b/test/test_ecu.py
@@ -200,3 +200,24 @@ def test_add_bus_filters(feeder):
     ]
     feeder.ecu.add_bus_filters(filters)
     assert feeder.ecu._bus.filters == filters
+
+def test_subscribe_unique(feeder):
+    """
+    Test unique subscribing to messages
+    """
+    call_count = 0
+
+    def callback(msg):
+        nonlocal call_count
+        call_count += 1
+
+    feeder.ecu.unique_subscribe(callback)
+    feeder.ecu.unique_subscribe(callback)  # should not add again
+    
+    feeder.can_messages = [
+        (Feeder.MsgType.CANRX, 0x00FEB201, [1, 2, 3, 4, 5, 6, 7, 8], 0.0),
+    ]
+
+    feeder.receive()
+
+    assert call_count == 1

--- a/test/test_memory_access.py
+++ b/test/test_memory_access.py
@@ -222,7 +222,7 @@ def test_dm14_read(feeder, expected_messages):
     :param feeder: can message feeder
     :param expected_messages: list of expected messages
     """
-    feeder.can_messages = expected_messages
+    feeder.can_messages = list(expected_messages)
     feeder.pdus_from_messages()
 
     ca = feeder.accept_all_messages(
@@ -233,6 +233,11 @@ def test_dm14_read(feeder, expected_messages):
 
     if expected_messages == read_with_seed_key:
         dm14.set_seed_key_algorithm(key_from_seed)
+
+    dm14.read(0xD4, 1, 0x92000003, 1)
+
+    feeder.process_messages()
+    feeder.can_messages = list(expected_messages)
 
     dm14.read(0xD4, 1, 0x92000003, 1)
 
@@ -410,7 +415,7 @@ def test_dm14_request_write(feeder, expected_messages):
     :param feeder: can message feeder
     :param expected_messages: list of expected messages
     """
-    feeder.can_messages = expected_messages
+    feeder.can_messages = list(expected_messages)
     feeder.pdus_from_messages()
     ca = feeder.accept_all_messages(
         device_address_preferred=0xD4, bypass_address_claim=True
@@ -434,6 +439,24 @@ def test_dm14_request_write(feeder, expected_messages):
         dm14.set_seed_key_algorithm(key_from_seed)
         dm14.set_verify_key(verify_key)
     values = 0x11223344
+    while flag is False:
+        pass
+    reset_flag()
+    test = dm14.respond(True, [], 0xFFFF, 0xFF)
+    assert values == int.from_bytes(test, byteorder="little", signed=False)
+
+    feeder.process_messages()
+
+    feeder.can_messages = list(expected_messages)
+
+    ca.send_pgn(
+        0,
+        (j1939.ParameterGroupNumber.PGN.DM14 >> 8) & 0xFF,
+        0xF9 & 0xFF,
+        6,
+        [0x01, 0x13, 0x03, 0x00, 0x00, 0x92, 0x07, 0x00],
+    )
+
     while flag is False:
         pass
     reset_flag()


### PR DESCRIPTION
When testing this more I discovered a couple issues, one of the issues was that we weren't properly cleaning up state after a transaction was completed in the memory access class. This was causing some flakiness when trying to do multiple reads. Another thing I noticed was tangentially related to that, if we had an error occur in the transaction we didn't properly clean that up and there were times where we were subscribing the same callback multiple times, so I added a unique_subscribe method to the ecu to only subscribe if it isn't already subscribed. This helps us to make sure that we aren't subscribing methods multiple times without needing to check in multiple places. 

I also expanded some coverage to have a test where we do multiple successful reads and writes

I suspect there are more underlying bugs, I'm currently investigating this more, will make a new pr if I find anything else